### PR TITLE
Remove architecture_independent declaration from ROS 2 package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,6 @@
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
-    <architecture_independent/>
     <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
This declaration is causing build failures on RHEL 8 where architecture
independence is checked.